### PR TITLE
Ignore unknown locales; English output is better than crashing

### DIFF
--- a/devede.py
+++ b/devede.py
@@ -136,7 +136,10 @@ else:
 #####################
 
 gettext.bindtextdomain('devede',share_locale)
-locale.setlocale(locale.LC_ALL,"")
+try:
+    locale.setlocale(locale.LC_ALL,"")
+except locale.Error:
+    pass
 gettext.textdomain('devede')
 gettext.install("devede",localedir=share_locale) # None is sys default locale
 #   Note also before python 2.3 you need the following if


### PR DESCRIPTION
Hello,

This patch has been added on the official Ubuntu package by Colin Watson in order to fix this bug: https://bugs.launchpad.net/bugs/746415 (devede crashed with Error in setlocale(): unsupported locale setting)
It seems he had no time to forward it to Devede team. Now it's done ;)

PS: thank you for this useful tool ;)
