### PR TITLE
Don't fail when wdir.get_current_folder() returns None.

### DIFF
--- a/devede_convert.py
+++ b/devede_convert.py
@@ -355,6 +355,8 @@ class create_all:
 		self.filename.replace("\\","_")
 		
 		filefolder=wdir.get_current_folder()
+		if filefolder is None: 
+			filefolder="/tmp"
 		
 		wfolder_dialog.hide()
 		wfolder_dialog.destroy()


### PR DESCRIPTION
My patch fixes that, but it is possibly more a workaround than a true fix.

Video DVD,
-> add a single mp4 file,
  -> OK
-> Forward
-> choose $HOME/Downloads Folder instead of (None)
  -> OK

Threads: 1
Creating window /usr/share/devede/wprogress.ui
Creating window /usr/share/devede/wfolder_dialog.ui
Entro en RUN
Salgo de RUN
Traceback (most recent call last):
  File "/usr/lib/python2.7/site-packages/devede_main.py", line 475, in on_main_go_clicked
    if conversor.create_disc():
  File "/usr/lib/python2.7/site-packages/devede_convert.py", line 365, in create_disc
    filefolder2=os.path.join(filefolder,self.filename)
  File "/usr/lib/python2.7/posixpath.py", line 68, in join
    elif path == '' or path.endswith('/'):
AttributeError: 'NoneType' object has no attribute 'endswith'
